### PR TITLE
Improve general flexibility; improve compatibility with Inventorio mod

### DIFF
--- a/src/main/java/com/spanser/reacharound/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/com/spanser/reacharound/mixin/client/MinecraftClientMixin.java
@@ -48,21 +48,17 @@ public abstract class MinecraftClientMixin extends ReentrantThreadExecutor<Runna
         }
     }
 
-    @Redirect(method = "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Hand;values()[Lnet/minecraft/util/Hand;"))
-    private Hand[] onItemUse() {
-        Hand[] handValues = Hand.values();
+    @Redirect(method = "doItemUse", at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/network/ClientPlayerEntity;getStackInHand(Lnet/minecraft/util/Hand;)Lnet/minecraft/item/ItemStack;"
+    ))
+    private ItemStack onItemUse(ClientPlayerEntity player, Hand hand) {
+        ItemStack itemStack = player.getStackInHand(hand);
 
-        if (!Reacharound.getInstance().config.enabled) {
-            return handValues;
+        if (Reacharound.getInstance().config.enabled) {
+            PlacementFeature.executeReacharound(instance, hand, itemStack);
         }
 
-        for (Hand hand : handValues) {
-            ItemStack itemStack = player.getStackInHand(hand);
-
-            if (PlacementFeature.executeReacharound(instance, hand, itemStack)) {
-                break;
-            }
-        }
-        return handValues;
+        return itemStack;
     }
 }


### PR DESCRIPTION
By changing out the doItemUse redirect to one focusing on a smaller scope, it was possible to remove the code determining active hand. As well as making it more elegant by not duplicating functionality, it also improves compatibility with Inventorio, another mod (it also redirects the entire Hand method, but it actually needs the larger scope). 