### PR TITLE
feat: Update for 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version "${loom_version}"
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.16.14
 loom_version=1.11-SNAPSHOT
 #Fabric api
-fabric_version=0.128.2+1.21.6
-quilt_loader_version=0.26.4
+fabric_version=0.131.0+1.21.8
+quilt_loader_version=0.29.1
 # Mod Properties
 mod_version=1.4.0
 maven_group=com.spanser


### PR DESCRIPTION
Increments the fabric versions for 1.21.8. A download is available on [my fork's releases page](https://github.com/Meshiest/reacharound/releases/tag/1.21.8)